### PR TITLE
Migrate to SpeziStorage 2.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,7 +39,7 @@ jobs:
       path: 'Tests/UITests'
       scheme: TestApp
       resultBundle: TestAppiPadOS.xcresult
-      destination: 'platform=iOS Simulator,name=iPad mini (6th generation)'
+      destination: 'platform=iOS Simulator,name=iPad mini (A17 Pro)'
       artifactname: TestAppiPadOS.xcresult
   uploadcoveragereport:
     name: Upload Coverage Report

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.2.3"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "1.0.2"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "2.0.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.3.1")
     ],
     targets: [
@@ -30,7 +30,7 @@ let package = Package(
             name: "SpeziAccessGuard",
             dependencies: [
                 .product(name: "Spezi", package: "Spezi"),
-                .product(name: "SpeziSecureStorage", package: "SpeziStorage"),
+                .product(name: "SpeziKeychainStorage", package: "SpeziStorage"),
                 .product(name: "SpeziViews", package: "SpeziViews")
             ]
         ),

--- a/Sources/SpeziAccessGuard/AccessGuard.swift
+++ b/Sources/SpeziAccessGuard/AccessGuard.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Observation
 import Spezi
-import SpeziSecureStorage
+import SpeziKeychainStorage
 import SwiftUI
 
 
@@ -64,7 +64,7 @@ import SwiftUI
 /// ```
 @Observable
 public final class AccessGuard {
-    private let secureStorage: SecureStorage
+    private let keychainStorage: KeychainStorage
     
     private(set) var inTheBackground = true
     private(set) var lastEnteredBackground: Date = .now
@@ -72,8 +72,8 @@ public final class AccessGuard {
     private var viewModels: [String: AccessGuardViewModel] = [:]
     
     
-    init(secureStorage: SecureStorage, _ configurations: [AccessGuardConfiguration]) {
-        self.secureStorage = secureStorage
+    init(keychainStorage: KeychainStorage, _ configurations: [AccessGuardConfiguration]) {
+        self.keychainStorage = keychainStorage
         self.configurations = configurations
     }
     
@@ -139,7 +139,7 @@ public final class AccessGuard {
         }
         
         guard let viewModel = viewModels[identifier] else {
-            let viewModel = AccessGuardViewModel(accessGuard: self, secureStorage: secureStorage, configuration: configuration)
+            let viewModel = AccessGuardViewModel(accessGuard: self, keychainStorage: keychainStorage, configuration: configuration)
             viewModels[identifier] = viewModel
             return viewModel
         }

--- a/Sources/SpeziAccessGuard/AccessGuardModule.swift
+++ b/Sources/SpeziAccessGuard/AccessGuardModule.swift
@@ -8,7 +8,7 @@
 
 import Combine
 import Spezi
-import SpeziSecureStorage
+import SpeziKeychainStorage
 import SwiftUI
 
 
@@ -40,7 +40,7 @@ import SwiftUI
 /// You can use the ``AccessGuarded`` SwiftUI [`View`](https://developer.apple.com/documentation/swiftui/view) in your SwiftUI application to
 /// enforce a code or biometrics-based access guard to SwiftUI views.
 public final class AccessGuardModule: Module, DefaultInitializable, LifecycleHandler {
-    @Dependency private var secureStorage: SecureStorage
+    @Dependency(KeychainStorage.self) private var keychainStorage
     /// Shared ``AccessGuard`` type used to lock, reset, and inspect access control mechanisms.
     @Model public private(set) var accessGuard: AccessGuard
     
@@ -58,7 +58,7 @@ public final class AccessGuardModule: Module, DefaultInitializable, LifecycleHan
     
     @_documentation(visibility: internal)
     public func configure() {
-        accessGuard = AccessGuard(secureStorage: secureStorage, configurations)
+        accessGuard = AccessGuard(keychainStorage: keychainStorage, configurations)
     }
     
     

--- a/Sources/SpeziAccessGuard/AccessGuardViewModel.swift
+++ b/Sources/SpeziAccessGuard/AccessGuardViewModel.swift
@@ -147,5 +147,5 @@ final class AccessGuardViewModel {
 
 
 extension CredentialsTag {
-    static let accessGuard = Self.genericPassword(forService: "accessGuard")
+    static let accessGuard = Self.genericPassword(forService: "edu.stanford.spezi.accessGuard")
 }

--- a/Sources/SpeziAccessGuard/AccessGuardViewModel.swift
+++ b/Sources/SpeziAccessGuard/AccessGuardViewModel.swift
@@ -9,7 +9,7 @@
 import LocalAuthentication
 import Observation
 import Spezi
-import SpeziSecureStorage
+import SpeziKeychainStorage
 import SwiftUI
 
 
@@ -22,7 +22,7 @@ final class AccessGuardViewModel {
     
     
     let configuration: AccessGuardConfiguration
-    private let secureStorage: SecureStorage
+    private let keychainStorage: KeychainStorage
     
     @MainActor private(set) var locked = true
     @MainActor private var accessCode: AccessCode?
@@ -43,12 +43,12 @@ final class AccessGuardViewModel {
     
     
     @MainActor
-    init(accessGuard: AccessGuard, secureStorage: SecureStorage, configuration: AccessGuardConfiguration) {
+    init(accessGuard: AccessGuard, keychainStorage: KeychainStorage, configuration: AccessGuardConfiguration) {
         self.configuration = configuration
         self.accessGuard = accessGuard
-        self.secureStorage = secureStorage
+        self.keychainStorage = keychainStorage
         
-        if let credentials = try? secureStorage.retrieveCredentials(configuration.identifier),
+        if let credentials = try? keychainStorage.retrieveCredentials(withUsername: configuration.identifier, for: .accessGuard),
            let accessCode = try? JSONDecoder().decode(AccessCode.self, from: Data(credentials.password.utf8)),
            accessCode.codeOption.verifyStructure(ofCode: accessCode.code) {
             self.accessCode = accessCode
@@ -94,7 +94,7 @@ final class AccessGuardViewModel {
         }
         
         do {
-            try secureStorage.deleteCredentials(configuration.identifier)
+            try keychainStorage.deleteCredentials(withUsername: configuration.identifier, for: .accessGuard)
             accessCode = nil
             self.locked = setup
         } catch {
@@ -135,9 +135,17 @@ final class AccessGuardViewModel {
             throw AccessGuardError.storeCodeError
         }
         
-        try secureStorage.store(credentials: Credentials(username: configuration.identifier, password: accessCodeData))
+        try keychainStorage.store(
+            Credentials(username: configuration.identifier, password: accessCodeData),
+            for: .accessGuard)
         
         // Ensure that the model is in a state as if the user has just entered the access code.
         try await checkAccessCode(code)
     }
+}
+
+
+
+extension CredentialsTag {
+    static let accessGuard = Self.genericPassword(forService: "accessGuard")
 }

--- a/Sources/SpeziAccessGuard/AccessGuardViewModel.swift
+++ b/Sources/SpeziAccessGuard/AccessGuardViewModel.swift
@@ -137,13 +137,13 @@ final class AccessGuardViewModel {
         
         try keychainStorage.store(
             Credentials(username: configuration.identifier, password: accessCodeData),
-            for: .accessGuard)
+            for: .accessGuard
+        )
         
         // Ensure that the model is in a state as if the user has just entered the access code.
         try await checkAccessCode(code)
     }
 }
-
 
 
 extension CredentialsTag {

--- a/Sources/SpeziAccessGuard/AccessGuarded.swift
+++ b/Sources/SpeziAccessGuard/AccessGuarded.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import SpeziSecureStorage
+import SpeziKeychainStorage
 import SwiftUI
 
 

--- a/Sources/SpeziAccessGuard/SetAccessGuard.swift
+++ b/Sources/SpeziAccessGuard/SetAccessGuard.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import SpeziSecureStorage
+import SpeziKeychainStorage
 import SwiftUI
 
 


### PR DESCRIPTION
# Migrate to SpeziStorage 2.0

## :recycle: Current situation & Problem
The 2.0 release of SpeziStorage has fundamentally changed the API, which requires us to update this package.

## :gear: Release Notes 
- updated SpeziStorage dependency to 2.0

## :books: Documentation
n/a

## :white_check_mark: Testing
all tests still pass

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
