### PR TITLE
rework `AccessGuardIdentifier` into a struct

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -47,3 +47,6 @@ jobs:
     uses: StanfordSpezi/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
     with:
       coveragereports: SpeziAccessGuard.xcresult TestApp.xcresult TestAppiPadOS.xcresult
+    secrets:
+      token: ${{ secrets.CODECOV_TOKEN }}
+

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.8.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage.git", from: "2.1.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.9.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", branch: "lukas/new-stuff")
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.1.1")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -21,9 +21,10 @@ let package = Package(
         .library(name: "SpeziAccessGuard", targets: ["SpeziAccessGuard"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.2.3"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "2.0.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.3.1")
+        .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.2.3"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziStorage.git", from: "2.0.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.3.1"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", branch: "lukas/new-stuff")
     ],
     targets: [
         .target(
@@ -31,14 +32,17 @@ let package = Package(
             dependencies: [
                 .product(name: "Spezi", package: "Spezi"),
                 .product(name: "SpeziKeychainStorage", package: "SpeziStorage"),
-                .product(name: "SpeziViews", package: "SpeziViews")
-            ]
+                .product(name: "SpeziViews", package: "SpeziViews"),
+                .product(name: "SpeziFoundation", package: "SpeziFoundation")
+            ],
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")]
         ),
         .testTarget(
             name: "SpeziAccessGuardTests",
             dependencies: [
                 .target(name: "SpeziAccessGuard")
-            ]
+            ],
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -21,9 +21,9 @@ let package = Package(
         .library(name: "SpeziAccessGuard", targets: ["SpeziAccessGuard"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.2.3"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziStorage.git", from: "2.0.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.3.1"),
+        .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.8.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziStorage.git", from: "2.1.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.9.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", branch: "lukas/new-stuff")
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ import SpeziAccessGuard
 class ExampleDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration {
-            AccessGuardModule([
-                .code(identifier: .exampleAccessGuard, codeOptions: .fourDigitNumeric, timeout: 15 * 60)
-            ])
+            AccessGuardModule {
+                CodeAccessGuard(.exampleAccessGuard, codeOptions: .fourDigitNumeric, timeout: .minutes(15))
+            }
         }
     }
 }
@@ -78,9 +78,9 @@ import SpeziAccessGuard
 class ExampleDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration {
-            AccessGuardModule([
-                .biometric(identifier: .exampleAccessGuard, codeOptions: .fourDigitNumeric, timeout: 15 * 60)
-            ])
+            AccessGuardModule {
+                BiometricsAccessGuard(.exampleAccessGuard, codeOptions: .fourDigitNumeric, timeout: .minutes(15))
+            }
         }
     }
 }
@@ -98,9 +98,9 @@ import SpeziAccessGuard
 class ExampleDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration {
-            AccessGuardModule([
-                .fixed(identifier: .exampleAccessGuard, code: "1234", codeOptions: .fourDigitNumeric, timeout: 15 * 60)
-            ])
+            AccessGuardModule {
+                FixedAccessGuard(.exampleAccessGuard, code: "1234", codeOptions: .fourDigitNumeric, timeout: .minutes(15))
+            }
         }
     }
 }
@@ -118,10 +118,10 @@ import SpeziAccessGuard
 class ExampleDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration {
-            AccessGuardModule([
-                .biometric(identifier: .accessGuard1),
-                .fixed(identifier: .accessGuard2, code: "1234")
-            ])
+            AccessGuardModule {
+                BiometricsAccessGuard(.accessGuard1)
+                FixedAccessGuard(.accessGuard2, code: "1234")
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -51,17 +51,18 @@ In the example below, we configure the [`AccessGuardModule`](https://swiftpackag
 import Spezi
 import SpeziAccessGuard
 
-
 class ExampleDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration {
-            AccessGuardModule(
-                [
-                    .code(identifier: "ExampleIdentifier", codeOptions: .fourDigitNumeric, timeout: 15 * 60)
-                ]
-            )
+            AccessGuardModule([
+                .code(identifier: .exampleAccessGuard, codeOptions: .fourDigitNumeric, timeout: 15 * 60)
+            ])
         }
     }
+}
+
+extension AccessGuardIdentifier {
+    static let exampleAccessGuard = Self("edu.stanford.spezi.exampleAccessGuard")
 }
 ```
 
@@ -77,11 +78,9 @@ import SpeziAccessGuard
 class ExampleDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration {
-            AccessGuardModule(
-                [
-                    .biometric(identifier: "ExampleIdentifier", codeOptions: .fourDigitNumeric, timeout: 15 * 60)
-                ]
-            )
+            AccessGuardModule([
+                .biometric(identifier: .exampleAccessGuard, codeOptions: .fourDigitNumeric, timeout: 15 * 60)
+            ])
         }
     }
 }
@@ -99,11 +98,9 @@ import SpeziAccessGuard
 class ExampleDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration {
-            AccessGuardModule(
-                [
-                    .fixed(identifier: "ExampleIdentifier", code: "1234", codeOptions: .fourDigitNumeric, timeout: 15 * 60)
-                ]
-            )
+            AccessGuardModule([
+                .fixed(identifier: .exampleAccessGuard, code: "1234", codeOptions: .fourDigitNumeric, timeout: 15 * 60)
+            ])
         }
     }
 }
@@ -121,14 +118,17 @@ import SpeziAccessGuard
 class ExampleDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration {
-            AccessGuardModule(
-                [
-                    .biometric(identifier: "ExampleIdentifier"),
-                    .fixed(identifier: "ExampleFixedIdentifier", code: "1234")
-                ]
-            )
+            AccessGuardModule([
+                .biometric(identifier: .accessGuard1),
+                .fixed(identifier: .accessGuard2, code: "1234")
+            ])
         }
     }
+}
+
+extension AccessGuardIdentifier {
+    static let accessGuard1 = Self("edu.stanford.spezi.exampleAccessGuard1")
+    static let accessGuard2 = Self("edu.stanford.spezi.exampleAccessGuard2")
 }
 ```
 
@@ -155,7 +155,7 @@ import SpeziAccessGuard
 
 struct SetAccessCode: View {
     var body: some View {
-        SetAccessGuard(identifier: "ExampleIdentifier")
+        SetAccessGuard(identifier: .exampleAccessGuard)
     }
 }
 ```
@@ -169,7 +169,7 @@ import SpeziAccessGuard
 
 struct ProtectedContent: View {    
     var body: some View {
-        AccessGuarded("ExampleIdentifier") {
+        AccessGuarded(.exampleAccessGuard) {
             Text("Secured content...")
         }
     }
@@ -185,13 +185,13 @@ struct ProtectedContent: View {
     @Environment(AccessGuard.self) private var accessGuard
     
     var body: some View {
-        AccessGuarded("ExampleIdentifier") {
+        AccessGuarded(.exampleAccessGuard) {
             Text("Secured content...")
         }
         .toolbar {
             ToolbarItem {
                 Button("Lock Access Guard") {
-                    try? accessGuard.lock(identifier: "ExampleIdentifier")
+                    try? accessGuard.lock(identifier: .exampleAccessGuard)
                 }
             }
         }
@@ -208,13 +208,13 @@ struct ProtectedContent: View {
     @Environment(AccessGuard.self) private var accessGuard
     
     var body: some View {
-        AccessGuarded("ExampleIdentifier") {
+        AccessGuarded(.exampleAccessGuard) {
             Text("Secured content...")
         }
         .toolbar {
             ToolbarItem {
                 Button("Reset Access Guard") {
-                    try? accessGuard.resetAccessCode(for: "ExampleIdentifier")
+                    try? accessGuard.resetAccessCode(for: .exampleAccessGuard)
                 }
             }
         }

--- a/Sources/SpeziAccessGuard/AccessGuard.swift
+++ b/Sources/SpeziAccessGuard/AccessGuard.swift
@@ -69,7 +69,7 @@ public final class AccessGuard {
     private(set) var inTheBackground = true
     private(set) var lastEnteredBackground: Date = .now
     private let configurations: [AccessGuardConfiguration]
-    private var viewModels: [String: AccessGuardViewModel] = [:]
+    private var viewModels: [AccessGuardIdentifier: AccessGuardViewModel] = [:]
     
     
     init(keychainStorage: KeychainStorage, _ configurations: [AccessGuardConfiguration]) {
@@ -105,7 +105,7 @@ public final class AccessGuard {
     /// The function removes the code and all stored information.
     /// - Parameter identifier: The identifier of the access guard.
     @MainActor
-    public func resetAccessCode(for identifier: AccessGuardConfiguration.Identifier) throws {
+    public func resetAccessCode(for identifier: AccessGuardIdentifier) throws {
         try viewModel(for: identifier).resetAccessCode()
     }
     
@@ -115,19 +115,19 @@ public final class AccessGuard {
     /// - Parameter identifier: The identifier of the access guard.
     /// - Returns: Returns `true` of the access guard is successfully setup. False if no access guard is setup.
     @MainActor
-    public func setupComplete(for identifier: AccessGuardConfiguration.Identifier) -> Bool {
+    public func setupComplete(for identifier: AccessGuardIdentifier) -> Bool {
         viewModel(for: identifier).setup
     }
     
     /// Locks an access guard.
     /// - Parameter identifier: The identifier of the access guard that should be locked.
     @MainActor
-    public func lock(identifier: AccessGuardConfiguration.Identifier) async {
+    public func lock(identifier: AccessGuardIdentifier) async {
         await viewModel(for: identifier).lock()
     }
     
     @MainActor
-    func viewModel(for identifier: AccessGuardConfiguration.Identifier) -> AccessGuardViewModel {
+    func viewModel(for identifier: AccessGuardIdentifier) -> AccessGuardViewModel {
         guard let configuration = configurations.first(where: { $0.identifier == identifier }) else {
             preconditionFailure(
             """

--- a/Sources/SpeziAccessGuard/AccessGuard.swift
+++ b/Sources/SpeziAccessGuard/AccessGuard.swift
@@ -26,17 +26,21 @@ import SwiftUI
 ///     @Environment(AccessGuard.self) private var accessGuard
 ///     
 ///     var body: some View {
-///         AccessGuarded("ExampleIdentifier") {
+///         AccessGuarded(.myAccessGuard) {
 ///             Text("Secured content...")
 ///         }
 ///         .toolbar {
 ///             ToolbarItem {
 ///                 Button("Lock Access Guard") {
-///                     try? accessGuard.lock(identifier: "ExampleIdentifier")
+///                     try? accessGuard.lock(identifier: .myAccessGuard)
 ///                 }
 ///             }
 ///         }
 ///     }
+/// }
+///
+/// extension AccessGuardIdentifier {
+///     static let myAccessGuard = Self("edu.stanford.spezi.myAccessGuard")
 /// }
 /// ```
 /// 
@@ -49,13 +53,13 @@ import SwiftUI
 ///     @Environment(AccessGuard.self) private var accessGuard
 ///     
 ///     var body: some View {
-///         AccessGuarded("ExampleIdentifier") {
+///         AccessGuarded(.myAccessGuard) {
 ///             Text("Secured content...")
 ///         }
 ///         .toolbar {
 ///             ToolbarItem {
 ///                 Button("Reset Access Guard") {
-///                     try? accessGuard.resetAccessCode(for: "ExampleIdentifier")
+///                     try? accessGuard.resetAccessCode(for: .myAccessGuard)
 ///                 }
 ///             }
 ///         }

--- a/Sources/SpeziAccessGuard/AccessGuardConfiguration.swift
+++ b/Sources/SpeziAccessGuard/AccessGuardConfiguration.swift
@@ -12,9 +12,6 @@ import SpeziViews
 
 /// Configures the behaviour of the ``AccessGuard`` view.
 public struct AccessGuardConfiguration {
-    /// Unique identifier for the ``AccessGuardConfiguration``
-    public typealias Identifier = String
-    
     /// The defaults for the ``AccessGuardConfiguration``
     public enum Defaults {
         /// Default code option, subject to change in the future.
@@ -24,7 +21,7 @@ public struct AccessGuardConfiguration {
     }
     
     
-    let identifier: Identifier
+    let identifier: AccessGuardIdentifier
     let guardType: GuardType
     let codeOptions: CodeOptions
     let timeout: TimeInterval
@@ -32,7 +29,7 @@ public struct AccessGuardConfiguration {
     
     
     init(
-        identifier: Identifier,
+        identifier: AccessGuardIdentifier,
         guardType: GuardType,
         codeOptions: CodeOptions,
         timeout: TimeInterval,
@@ -53,7 +50,7 @@ public struct AccessGuardConfiguration {
     ///
     /// > Warning: Not yet implemented
     private static func codeIfUnprotected(
-        identifier: Identifier,
+        identifier: AccessGuardIdentifier,
         codeOptions: CodeOptions = Defaults.codeOptions,
         timeout: TimeInterval = Defaults.timeout
     ) -> AccessGuardConfiguration {
@@ -65,7 +62,7 @@ public struct AccessGuardConfiguration {
     ///   - codeOptions: The code options, see ``CodeOptions``.
     ///   - timeout: The timeout when the view should be locked based on the time the scene is not in the foreground.
     public static func code(
-        identifier: Identifier,
+        identifier: AccessGuardIdentifier,
         codeOptions: CodeOptions = .fourDigitNumeric,
         timeout: TimeInterval = Defaults.timeout
     ) -> AccessGuardConfiguration {
@@ -78,7 +75,7 @@ public struct AccessGuardConfiguration {
     ///   - codeOptions: The code options, see ``CodeOptions``.
     ///   - timeout: The timeout when the view should be locked based on the time the scene is not in the foreground.
     public static func fixed(
-        identifier: Identifier,
+        identifier: AccessGuardIdentifier,
         code: String,
         codeOptions: CodeOptions = .fourDigitNumeric,
         timeout: TimeInterval = Defaults.timeout
@@ -92,7 +89,7 @@ public struct AccessGuardConfiguration {
     ///   - timeout: The timeout when the view should be locked based on the time the scene is not in the foreground.
     ///
     public static func biometrics(
-        identifier: Identifier,
+        identifier: AccessGuardIdentifier,
         codeOptions: CodeOptions = .fourDigitNumeric,
         timeout: TimeInterval = Defaults.timeout
     ) -> AccessGuardConfiguration {

--- a/Sources/SpeziAccessGuard/AccessGuardConfiguration.swift
+++ b/Sources/SpeziAccessGuard/AccessGuardConfiguration.swift
@@ -7,92 +7,72 @@
 //
 
 import Foundation
+import SpeziFoundation
 import SpeziViews
 
 
 /// Configures the behaviour of the ``AccessGuard`` view.
 public struct AccessGuardConfiguration {
-    /// The defaults for the ``AccessGuardConfiguration``
-    public enum Defaults {
-        /// Default code option, subject to change in the future.
-        public static let codeOptions: CodeOptions = .fourDigitNumeric
-        /// Default timeout option, subject to change in the future.
-        public static let timeout: TimeInterval = 5 * 60
-    }
-    
-    
     let identifier: AccessGuardIdentifier
     let guardType: GuardType
     let codeOptions: CodeOptions
-    let timeout: TimeInterval
+    let timeout: Duration
     let fixedCode: String?
+}
+
+
+/// Enforce an access code.
+/// - Parameters:
+///   - codeOptions: The code options, see ``CodeOptions``.
+///   - timeout: The timeout when the view should be locked based on the time the scene is not in the foreground.
+public func CodeAccessGuard( // swiftlint:disable:this identifier_name
+    _ identifier: AccessGuardIdentifier,
+    codeOptions: CodeOptions = .fourDigitNumeric,
+    timeout: Duration = .minutes(5)
+) -> AccessGuardConfiguration {
+    AccessGuardConfiguration(identifier: identifier, guardType: .code, codeOptions: codeOptions, timeout: timeout, fixedCode: nil)
+}
+
+
+/// Enforce a fixed access code.
+/// - Parameters:
+///   - code: The fixed access code.
+///   - codeOptions: The code options, see ``CodeOptions``.
+///   - timeout: The timeout when the view should be locked based on the time the scene is not in the foreground.
+public func FixedAccessGuard( // swiftlint:disable:this identifier_name
+    _ identifier: AccessGuardIdentifier,
+    code: String,
+    codeOptions: CodeOptions = .fourDigitNumeric,
+    timeout: Duration = .minutes(5)
+) -> AccessGuardConfiguration {
+    AccessGuardConfiguration(identifier: identifier, guardType: .code, codeOptions: codeOptions, timeout: timeout, fixedCode: code)
+}
+
+/// Enforce an access code & biometrics authentication if setup on the device.
+/// - Parameters:
+///   - codeOptions: The code options, see ``CodeOptions``.
+///   - timeout: The timeout when the view should be locked based on the time the scene is not in the foreground.
+///
+public func BiometricsAccessGuard( // swiftlint:disable:this identifier_name
+    _ identifier: AccessGuardIdentifier,
+    codeOptions: CodeOptions = .fourDigitNumeric,
+    timeout: Duration = .minutes(5)
+) -> AccessGuardConfiguration {
+    AccessGuardConfiguration(identifier: identifier, guardType: .biometrics, codeOptions: codeOptions, timeout: timeout, fixedCode: nil)
+}
     
     
-    init(
-        identifier: AccessGuardIdentifier,
-        guardType: GuardType,
-        codeOptions: CodeOptions,
-        timeout: TimeInterval,
-        fixedCode: String? = nil
-    ) {
-        self.identifier = identifier
-        self.guardType = guardType
-        self.codeOptions = codeOptions
-        self.timeout = timeout
-        self.fixedCode = fixedCode
-    }
-    
-    
-    /// Enforce an access code if the device is not protected with an access code.
-    /// - Parameters:
-    ///   - codeOptions: The code options, see ``CodeOptions``.
-    ///   - timeout: The timeout when the view should be locked based on the time the scene is not in the foreground.
-    ///
-    /// > Warning: Not yet implemented
-    private static func codeIfUnprotected(
-        identifier: AccessGuardIdentifier,
-        codeOptions: CodeOptions = Defaults.codeOptions,
-        timeout: TimeInterval = Defaults.timeout
-    ) -> AccessGuardConfiguration {
-        AccessGuardConfiguration(identifier: identifier, guardType: .codeIfUnprotected, codeOptions: codeOptions, timeout: timeout)
-    }
-    
-    /// Enforce an access code.
-    /// - Parameters:
-    ///   - codeOptions: The code options, see ``CodeOptions``.
-    ///   - timeout: The timeout when the view should be locked based on the time the scene is not in the foreground.
-    public static func code(
-        identifier: AccessGuardIdentifier,
-        codeOptions: CodeOptions = .fourDigitNumeric,
-        timeout: TimeInterval = Defaults.timeout
-    ) -> AccessGuardConfiguration {
-        AccessGuardConfiguration(identifier: identifier, guardType: .code, codeOptions: codeOptions, timeout: timeout)
-    }
-    
-    /// Enforce a fixed access code.
-    /// - Parameters:
-    ///   - code: The fixed access code.
-    ///   - codeOptions: The code options, see ``CodeOptions``.
-    ///   - timeout: The timeout when the view should be locked based on the time the scene is not in the foreground.
-    public static func fixed(
-        identifier: AccessGuardIdentifier,
-        code: String,
-        codeOptions: CodeOptions = .fourDigitNumeric,
-        timeout: TimeInterval = Defaults.timeout
-    ) -> AccessGuardConfiguration {
-        AccessGuardConfiguration(identifier: identifier, guardType: .code, codeOptions: codeOptions, timeout: timeout, fixedCode: code)
-    }
-    
-    /// Enforce an access code & biometrics authentication if setup on the device.
-    /// - Parameters:
-    ///   - codeOptions: The code options, see ``CodeOptions``.
-    ///   - timeout: The timeout when the view should be locked based on the time the scene is not in the foreground.
-    ///
-    public static func biometrics(
-        identifier: AccessGuardIdentifier,
-        codeOptions: CodeOptions = .fourDigitNumeric,
-        timeout: TimeInterval = Defaults.timeout
-    ) -> AccessGuardConfiguration {
-        AccessGuardConfiguration(identifier: identifier, guardType: .biometrics, codeOptions: codeOptions, timeout: timeout)
-    }
+/// Enforce an access code if the device is not protected with an access code.
+/// - Parameters:
+///   - codeOptions: The code options, see ``CodeOptions``.
+///   - timeout: The timeout when the view should be locked based on the time the scene is not in the foreground.
+///
+/// > Warning: Not yet implemented
+@available(*, unavailable, message: "Not yet implemented")
+public func CodeIfUnprotectedAccessGuard( // swiftlint:disable:this identifier_name
+    _ identifier: AccessGuardIdentifier,
+    codeOptions: CodeOptions = .fourDigitNumeric,
+    timeout: Duration = .minutes(5)
+) -> AccessGuardConfiguration {
+    AccessGuardConfiguration(identifier: identifier, guardType: .codeIfUnprotected, codeOptions: codeOptions, timeout: timeout, fixedCode: nil)
 }

--- a/Sources/SpeziAccessGuard/AccessGuardIdentifier.swift
+++ b/Sources/SpeziAccessGuard/AccessGuardIdentifier.swift
@@ -1,0 +1,28 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+/// Unique identifier for the ``AccessGuardConfiguration``.
+///
+/// It is recommended you use reverse DNS notation for these identifiers, in order to reduce the risk of collisions.
+/// Furthermore, the underlying raw values used for these should be stable, since they will in some cases be persisted across app launches.
+///
+/// Example:
+///
+/// ```swift
+/// extension AccessGuardIdentifier {
+///     static let accountView = Self("com.myApp.accountView")
+/// }
+/// ```
+public struct AccessGuardIdentifier: Hashable, Sendable {
+    let value: String
+    
+    /// Creates a new access guard
+    public init(_ value: String) {
+        self.value = value
+    }
+}

--- a/Sources/SpeziAccessGuard/AccessGuardModule.swift
+++ b/Sources/SpeziAccessGuard/AccessGuardModule.swift
@@ -8,6 +8,7 @@
 
 import Combine
 import Spezi
+import SpeziFoundation
 import SpeziKeychainStorage
 import SwiftUI
 
@@ -22,9 +23,9 @@ import SwiftUI
 /// class ExampleAppDelegate: SpeziAppDelegate {
 ///     override var configuration: Configuration {
 ///         Configuration {
-///             AccessGuardModule([
-///                 .code(identifier: .exampleAccessGuard)
-///             ])
+///             AccessGuardModule {
+///                 CodeAccessGuard(.exampleAccessGuard)
+///             }
 ///             // ...
 ///         }
 ///     }
@@ -46,11 +47,11 @@ public final class AccessGuardModule: Module, DefaultInitializable, LifecycleHan
     
     
     public convenience init() {
-        self.init([])
+        self.init { /* empty config */ }
     }
     
-    public init(_ configurations: [AccessGuardConfiguration]) {
-        self.configurations = configurations
+    public init(@ArrayBuilder<AccessGuardConfiguration> _ configurations: () -> [AccessGuardConfiguration]) {
+        self.configurations = configurations()
     }
     
     

--- a/Sources/SpeziAccessGuard/AccessGuardModule.swift
+++ b/Sources/SpeziAccessGuard/AccessGuardModule.swift
@@ -22,11 +22,9 @@ import SwiftUI
 /// class ExampleAppDelegate: SpeziAppDelegate {
 ///     override var configuration: Configuration {
 ///         Configuration {
-///             AccessGuardModule(
-///                 [
-///                     .code(identifier: "TestIdentifier")
-///                 ]
-///             )
+///             AccessGuardModule([
+///                 .code(identifier: .exampleAccessGuard)
+///             ])
 ///             // ...
 ///         }
 ///     }

--- a/Sources/SpeziAccessGuard/AccessGuardViewModel.swift
+++ b/Sources/SpeziAccessGuard/AccessGuardViewModel.swift
@@ -48,7 +48,7 @@ final class AccessGuardViewModel {
         self.accessGuard = accessGuard
         self.keychainStorage = keychainStorage
         
-        if let credentials = try? keychainStorage.retrieveCredentials(withUsername: configuration.identifier, for: .accessGuard),
+        if let credentials = try? keychainStorage.retrieveCredentials(withUsername: configuration.identifier.value, for: .accessGuard),
            let accessCode = try? JSONDecoder().decode(AccessCode.self, from: Data(credentials.password.utf8)),
            accessCode.codeOption.verifyStructure(ofCode: accessCode.code) {
             self.accessCode = accessCode
@@ -94,7 +94,7 @@ final class AccessGuardViewModel {
         }
         
         do {
-            try keychainStorage.deleteCredentials(withUsername: configuration.identifier, for: .accessGuard)
+            try keychainStorage.deleteCredentials(withUsername: configuration.identifier.value, for: .accessGuard)
             accessCode = nil
             self.locked = setup
         } catch {
@@ -136,7 +136,7 @@ final class AccessGuardViewModel {
         }
         
         try keychainStorage.store(
-            Credentials(username: configuration.identifier, password: accessCodeData),
+            Credentials(username: configuration.identifier.value, password: accessCodeData),
             for: .accessGuard
         )
         

--- a/Sources/SpeziAccessGuard/AccessGuardViewModel.swift
+++ b/Sources/SpeziAccessGuard/AccessGuardViewModel.swift
@@ -65,7 +65,7 @@ final class AccessGuardViewModel {
     
     @MainActor
     func willEnterForeground(lastEnteredBackground: Date) {
-        if lastEnteredBackground.addingTimeInterval(configuration.timeout) < .now {
+        if lastEnteredBackground.addingTimeInterval(configuration.timeout.timeInterval) < .now {
             locked = true
         }
     }

--- a/Sources/SpeziAccessGuard/AccessGuarded.swift
+++ b/Sources/SpeziAccessGuard/AccessGuarded.swift
@@ -16,7 +16,7 @@ import SwiftUI
 /// in a [`SpeziAppDelegate`](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/speziappdelegate) as detailed in the ``AccessGuard`` documentation.
 ///
 /// ```swift
-/// AccessGuarded(identifier: "TestIdentifier") {
+/// AccessGuarded(identifier: .accessGuardIdentifier) {
 ///     Text("Secured View")
 /// }
 /// ```

--- a/Sources/SpeziAccessGuard/AccessGuarded.swift
+++ b/Sources/SpeziAccessGuard/AccessGuarded.swift
@@ -25,7 +25,7 @@ import SwiftUI
 public struct AccessGuarded<GuardedView: View>: View {
     @Environment(AccessGuard.self) private var accessGuard
     
-    private let identifier: AccessGuardConfiguration.Identifier
+    private let identifier: AccessGuardIdentifier
     private let guardedView: GuardedView
     
     
@@ -41,7 +41,7 @@ public struct AccessGuarded<GuardedView: View>: View {
     ///   - identifier: The identifier of the access guard configuration that should be used to guard this view.
     ///   - guarded: The guarded view.
     public init(
-        _ identifier: AccessGuardConfiguration.Identifier,
+        _ identifier: AccessGuardIdentifier,
         @ViewBuilder guarded guardedView: () -> GuardedView
     ) {
         self.identifier = identifier
@@ -50,10 +50,11 @@ public struct AccessGuarded<GuardedView: View>: View {
 }
 
 
-struct AccessCodeGuard_Previews: PreviewProvider {
-    static var previews: some View {
-        AccessGuarded("MyGuardedView") {
-            Text(verbatim: "Guarded View")
-        }
+#if DEBUG
+#Preview {
+    let identifier = AccessGuardIdentifier("edu.stanford.spezi.myView")
+    AccessGuarded(identifier) {
+        Text("Super secret stuff 🤫")
     }
 }
+#endif

--- a/Sources/SpeziAccessGuard/SetAccessGuard.swift
+++ b/Sources/SpeziAccessGuard/SetAccessGuard.swift
@@ -14,7 +14,7 @@ import SwiftUI
 public struct SetAccessGuard: View {
     @Environment(AccessGuard.self) private var accessGuard
     
-    private let identifier: AccessGuardConfiguration.Identifier
+    private let identifier: AccessGuardIdentifier
     private let action: @MainActor () async -> Void
     
     
@@ -27,10 +27,10 @@ public struct SetAccessGuard: View {
     ///   - identifier: The identifier of the access guard configuration that should be used to guard this view.
     ///   - action: An action that should be performed once the password has been set.
     public init(
-        identifier: AccessGuardConfiguration.Identifier,
-        action: (@MainActor () async -> Void)? = nil
+        identifier: AccessGuardIdentifier,
+        action: @escaping @MainActor () async -> Void = {}
     ) {
         self.identifier = identifier
-        self.action = action ?? {}
+        self.action = action
     }
 }

--- a/Sources/SpeziAccessGuard/SpeziAccessGuard.docc/SpeziAccessGuard.md
+++ b/Sources/SpeziAccessGuard/SpeziAccessGuard.docc/SpeziAccessGuard.md
@@ -54,11 +54,9 @@ import SpeziAccessGuard
 class ExampleDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration {
-            AccessGuardModule(
-                [
-                    .code(identifier: "ExampleIdentifier", codeOptions: .fourDigitNumeric, timeout: 15 * 60)
-                ]
-            )
+            AccessGuardModule([
+                .code(identifier: .exampleAccessGuard, codeOptions: .fourDigitNumeric, timeout: 15 * 60)
+            ])
         }
     }
 }
@@ -77,11 +75,9 @@ import SpeziAccessGuard
 class ExampleDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration {
-            AccessGuardModule(
-                [
-                    .biometric(identifier: "ExampleIdentifier", codeOptions: .fourDigitNumeric, timeout: 15 * 60)
-                ]
-            )
+            AccessGuardModule([
+                .biometric(identifier: .exampleAccessGuard, codeOptions: .fourDigitNumeric, timeout: 15 * 60)
+            ])
         }
     }
 }
@@ -99,11 +95,9 @@ import SpeziAccessGuard
 class ExampleDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration {
-            AccessGuardModule(
-                [
-                    .fixed(identifier: "ExampleIdentifier", code: "1234")
-                ]
-            )
+            AccessGuardModule([
+                .fixed(identifier: .exampleAccessGuard, code: "1234")
+            ])
         }
     }
 }
@@ -121,14 +115,17 @@ import SpeziAccessGuard∂
 class ExampleDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration {
-            AccessGuardModule(
-                [
-                    .biometric(identifier: "ExampleIdentifier"),
-                    .fixed(identifier: "ExampleFixedIdentifier", code: "1234")
-                ]
-            )
+            AccessGuardModule([
+                .biometric(identifier: .accessGuard1),
+                .fixed(identifier: .accessGuard2, code: "1234")
+            ])
         }
     }
+}
+
+extension AccessGuardIdentifier {
+    static let accessGuard1 = Self("edu.stanford.spezi.exampleAccessGuard1")
+    static let accessGuard2 = Self("edu.stanford.spezi.exampleAccessGuard2")
 }
 ```
 
@@ -154,7 +151,7 @@ import SpeziAccessGuard
 
 struct SetAccessCode: View {
     var body: some View {
-        SetAccessGuard(identifier: "ExampleIdentifier")
+        SetAccessGuard(identifier: .exampleAccessGuard)
     }
 }
 ```
@@ -168,7 +165,7 @@ import SpeziAccessGuard
 
 struct ProtectedContent: View {    
     var body: some View {
-        AccessGuarded("ExampleIdentifier") {
+        AccessGuarded(.exampleAccessGuard) {
             Text("Secured content...")
         }
     }
@@ -184,13 +181,13 @@ struct ProtectedContent: View {
     @Environment(AccessGuard.self) private var accessGuard
     
     var body: some View {
-        AccessGuarded("ExampleIdentifier") {
+        AccessGuarded(.exampleAccessGuard) {
             Text("Secured content...")
         }
         .toolbar {
             ToolbarItem {
                 Button("Lock Access Guard") {
-                    try? accessGuard.lock(identifier: "ExampleIdentifier")
+                    try? accessGuard.lock(identifier: .exampleAccessGuard)
                 }
             }
         }
@@ -207,13 +204,13 @@ struct ProtectedContent: View {
     @Environment(AccessGuard.self) private var accessGuard
     
     var body: some View {
-        AccessGuarded("ExampleIdentifier") {
+        AccessGuarded(.exampleAccessGuard) {
             Text("Secured content...")
         }
         .toolbar {
             ToolbarItem {
                 Button("Reset Access Guard") {
-                    try? accessGuard.resetAccessCode(for: "ExampleIdentifier")
+                    try? accessGuard.resetAccessCode(for: .exampleAccessGuard)
                 }
             }
         }

--- a/Sources/SpeziAccessGuard/SpeziAccessGuard.docc/SpeziAccessGuard.md
+++ b/Sources/SpeziAccessGuard/SpeziAccessGuard.docc/SpeziAccessGuard.md
@@ -54,9 +54,9 @@ import SpeziAccessGuard
 class ExampleDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration {
-            AccessGuardModule([
-                .code(identifier: .exampleAccessGuard, codeOptions: .fourDigitNumeric, timeout: 15 * 60)
-            ])
+            AccessGuardModule {
+                CodeAccessGuard(.exampleAccessGuard, codeOptions: .fourDigitNumeric, timeout: .minutes(15))
+            }
         }
     }
 }
@@ -75,9 +75,9 @@ import SpeziAccessGuard
 class ExampleDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration {
-            AccessGuardModule([
-                .biometric(identifier: .exampleAccessGuard, codeOptions: .fourDigitNumeric, timeout: 15 * 60)
-            ])
+            AccessGuardModule {
+                BiometricsAccessGuard(.exampleAccessGuard, codeOptions: .fourDigitNumeric, timeout: .minutes(15))
+            }
         }
     }
 }
@@ -95,9 +95,9 @@ import SpeziAccessGuard
 class ExampleDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration {
-            AccessGuardModule([
-                .fixed(identifier: .exampleAccessGuard, code: "1234")
-            ])
+            AccessGuardModule {
+                FixedAccessGuard(.exampleAccessGuard, code: "1234")
+            }
         }
     }
 }
@@ -115,10 +115,10 @@ import SpeziAccessGuard∂
 class ExampleDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration {
-            AccessGuardModule([
-                .biometric(identifier: .accessGuard1),
-                .fixed(identifier: .accessGuard2, code: "1234")
-            ])
+            AccessGuardModule {
+                BiometricsAccessGuard(.accessGuard1)
+                FixedAccessGuard(.accessGuard2, code: "1234")
+            }
         }
     }
 }

--- a/Tests/SpeziAccessGuardTests/LAContextTests.swift
+++ b/Tests/SpeziAccessGuardTests/LAContextTests.swift
@@ -17,7 +17,7 @@ class MockLAContext: LAContext {
     override func evaluatePolicy(
         _ policy: LAPolicy,
         localizedReason: String,
-        reply: @escaping (Bool, Error?) -> Void
+        reply: @escaping (Bool, (any Error)?) -> Void
     ) {
         if shouldSucceed {
             reply(true, nil)
@@ -32,7 +32,6 @@ class LAContextTests: XCTestCase {
     func testEvaluatePolicyAsyncSuccess() async throws {
         let mockContext = MockLAContext()
         mockContext.shouldSucceed = true
-
         let result = try await mockContext.evaluatePolicyAsync(.deviceOwnerAuthenticationWithBiometrics, localizedReason: "Test for success")
         XCTAssertTrue(result, "Policy evaluation should succeed")
     }
@@ -40,7 +39,6 @@ class LAContextTests: XCTestCase {
     func testEvaluatePolicyAsyncFailure() async throws {
         let mockContext = MockLAContext()
         mockContext.shouldSucceed = false
-
         do {
             try await mockContext.evaluatePolicyAsync(.deviceOwnerAuthenticationWithBiometrics, localizedReason: "Test for failure")
             XCTFail("Policy evaluation should fail but succeeded")

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -19,7 +19,7 @@ struct ContentView: View {
         NavigationStack {
             List {
                 NavigationLink("Access Guarded") {
-                    AccessGuarded("TestIdentifier") {
+                    AccessGuarded(.test) {
                         Color.green
                             .overlay {
                                 Text("Secured ...")
@@ -27,7 +27,7 @@ struct ContentView: View {
                     }
                 }
                 NavigationLink("Access Guarded Fixed") {
-                    AccessGuarded("TestFixedIdentifier") {
+                    AccessGuarded(.testFixed) {
                         Color.green
                             .overlay {
                                 Text("Secured with fixed code ...")
@@ -35,7 +35,7 @@ struct ContentView: View {
                     }
                 }
                 NavigationLink("Access Guarded Biometrics") {
-                    AccessGuarded("TestBiometricsIdentifier") {
+                    AccessGuarded(.testBiometrics) {
                         Color.green
                             .overlay {
                                 Text("Secured with biometrics ...")
@@ -43,17 +43,17 @@ struct ContentView: View {
                     }
                 }
                 NavigationLink("Set Code") {
-                    SetAccessGuard(identifier: "TestIdentifier")
+                    SetAccessGuard(identifier: .test)
                 }
                 NavigationLink("Set Biometric Backup Code") {
-                    SetAccessGuard(identifier: "TestBiometricsIdentifier")
+                    SetAccessGuard(identifier: .testBiometrics)
                 }
             }
                 .toolbar {
                     ToolbarItem {
                         Button("Lock Access Guards") {
                             Task {
-                                let identifiers = ["TestIdentifier", "TestFixedIdentifier", "TestBiometricsIdentifier"]
+                                let identifiers: [AccessGuardIdentifier] = [.test, .testFixed, .testBiometrics]
                                 for identifier in identifiers {
                                     await accessGuard.lock(identifier: identifier)
                                 }
@@ -62,7 +62,7 @@ struct ContentView: View {
                     }
                     ToolbarItem {
                         Button("Reset Access Guards") {
-                            let identifiers = ["TestIdentifier", "TestBiometricsIdentifier"]
+                            let identifiers: [AccessGuardIdentifier] = [.test, .testBiometrics]
                             for identifier in identifiers {
                                 try? accessGuard.resetAccessCode(for: identifier)
                             }

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -14,13 +14,11 @@ import SwiftUI
 class TestAppDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration {
-            AccessGuardModule(
-                [
-                    .biometrics(identifier: .testBiometrics),
-                    .code(identifier: .test, timeout: 10),
-                    .fixed(identifier: .testFixed, code: "1234")
-                ]
-            )
+            AccessGuardModule {
+                BiometricsAccessGuard(.testBiometrics)
+                CodeAccessGuard(.test, timeout: .seconds(10))
+                FixedAccessGuard(.testFixed, code: "1234")
+            }
         }
     }
 }

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -16,11 +16,18 @@ class TestAppDelegate: SpeziAppDelegate {
         Configuration {
             AccessGuardModule(
                 [
-                    .biometrics(identifier: "TestBiometricsIdentifier"),
-                    .code(identifier: "TestIdentifier", timeout: 10),
-                    .fixed(identifier: "TestFixedIdentifier", code: "1234")
+                    .biometrics(identifier: .testBiometrics),
+                    .code(identifier: .test, timeout: 10),
+                    .fixed(identifier: .testFixed, code: "1234")
                 ]
             )
         }
     }
+}
+
+
+extension AccessGuardIdentifier {
+    static let test = Self("edu.stanford.spezi.accessguardtests.1.test")
+    static let testFixed = Self("edu.stanford.spezi.accessguardtests.1.testFixed")
+    static let testBiometrics = Self("edu.stanford.spezi.accessguardtests.1.testBiometrics")
 }


### PR DESCRIPTION
# rework `AccessGuardIdentifier` into a struct

## :recycle: Current situation & Problem
The AccessGuard module currently uses raw `String`s to identify individual access guards.
This PR reworks this system, by introducing an `AccessGuardIdentifier` type, which instead serves to identify access guards.

fixes #5 

## :gear: Release Notes 
- introduced `AccessGuardIdentifier`

## :books: Documentation
the documentation has been updated

## :white_check_mark: Testing
tests have been updated. since there is no new functionality, there also are no new tests.

## :pencil: Code of Conduct & Contributing Guidelines 
By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
