### PR TITLE
Filter invalid passcode characters and show descriptive error message

### DIFF
--- a/Sources/SpeziAccessGuard/CodeViews/CodeOptions.swift
+++ b/Sources/SpeziAccessGuard/CodeViews/CodeOptions.swift
@@ -69,7 +69,17 @@ extension PasscodeFormat {
             .asciiCapable
         }
     }
-    
+
+    /// A localized message to display when an invalid character is rejected.
+    var invalidCharacterMessage: LocalizedStringResource? {
+        switch self {
+        case .numeric:
+            LocalizedStringResource("PASSCODE_ONLY_DIGITS_ALLOWED", bundle: .module)
+        case .alphanumeric:
+            LocalizedStringResource("PASSCODE_ONLY_LETTERS_AND_DIGITS_ALLOWED", bundle: .module)
+        }
+    }
+
     func validate(code: String) -> Bool {
         switch self {
         case .numeric(.exact(let length)):
@@ -90,16 +100,6 @@ extension PasscodeFormat {
             code.filter(\.isNumber)
         case .alphanumeric:
             code.filter { $0.isNumber || $0.isLetter }
-        }
-    }
-
-    /// A localized message to display when an invalid character is rejected.
-    var invalidCharacterMessage: LocalizedStringResource? {
-        switch self {
-        case .numeric:
-            LocalizedStringResource("PASSCODE_ONLY_DIGITS_ALLOWED", bundle: .module)
-        case .alphanumeric:
-            LocalizedStringResource("PASSCODE_ONLY_LETTERS_AND_DIGITS_ALLOWED", bundle: .module)
         }
     }
 }

--- a/Sources/SpeziAccessGuard/CodeViews/CodeOptions.swift
+++ b/Sources/SpeziAccessGuard/CodeViews/CodeOptions.swift
@@ -97,9 +97,9 @@ extension PasscodeFormat {
     var invalidCharacterMessage: LocalizedStringResource? {
         switch self {
         case .numeric:
-            LocalizedStringResource("PASSCODE_ONLY_DIGITS_ALLOWED", bundle: .atURL(from: .module))
+            LocalizedStringResource("PASSCODE_ONLY_DIGITS_ALLOWED", bundle: .module)
         case .alphanumeric:
-            LocalizedStringResource("PASSCODE_ONLY_LETTERS_AND_DIGITS_ALLOWED", bundle: .atURL(from: .module))
+            LocalizedStringResource("PASSCODE_ONLY_LETTERS_AND_DIGITS_ALLOWED", bundle: .module)
         }
     }
 }

--- a/Sources/SpeziAccessGuard/CodeViews/CodeOptions.swift
+++ b/Sources/SpeziAccessGuard/CodeViews/CodeOptions.swift
@@ -82,6 +82,26 @@ extension PasscodeFormat {
             code.allSatisfy { $0.isNumber || $0.isLetter } && code.count >= minLength
         }
     }
+
+    /// Returns a copy of `code` with any characters disallowed by this format removed.
+    func filteringInvalidCharacters(from code: String) -> String {
+        switch self {
+        case .numeric:
+            code.filter(\.isNumber)
+        case .alphanumeric:
+            code.filter { $0.isNumber || $0.isLetter }
+        }
+    }
+
+    /// A localized message to display when an invalid character is rejected.
+    var invalidCharacterMessage: LocalizedStringResource? {
+        switch self {
+        case .numeric:
+            LocalizedStringResource("PASSCODE_ONLY_DIGITS_ALLOWED", bundle: .atURL(from: .module))
+        case .alphanumeric:
+            LocalizedStringResource("PASSCODE_ONLY_LETTERS_AND_DIGITS_ALLOWED", bundle: .atURL(from: .module))
+        }
+    }
 }
 
 

--- a/Sources/SpeziAccessGuard/CodeViews/CodeView.swift
+++ b/Sources/SpeziAccessGuard/CodeViews/CodeView.swift
@@ -78,7 +78,9 @@ struct CodeView: View {
             dismissTask?.cancel()
             dismissTask = Task { @MainActor in
                 try? await Task.sleep(for: .seconds(2))
-                guard !Task.isCancelled else { return }
+                guard !Task.isCancelled else {
+                    return
+                }
                 invalidCharacterMessage = nil
             }
             return

--- a/Sources/SpeziAccessGuard/CodeViews/CodeView.swift
+++ b/Sources/SpeziAccessGuard/CodeViews/CodeView.swift
@@ -50,7 +50,7 @@ struct CodeView: View {
                         focused = true
                     }
                 }
-                .task {
+                .onAppear {
                     focused = true
                 }
                 .onChange(of: code) {
@@ -80,8 +80,9 @@ struct CodeView: View {
                 guard !Task.isCancelled else { return }
                 invalidCharacterMessage = nil
             }
+            return
         }
-        if codeFormat.validate(code: code) {
+        if codeFormat.validate(code: filtered) {
             Task { @MainActor in
                 await checkCode()
             }

--- a/Sources/SpeziAccessGuard/CodeViews/CodeView.swift
+++ b/Sources/SpeziAccessGuard/CodeViews/CodeView.swift
@@ -58,6 +58,7 @@ struct CodeView: View {
                 }
             if let invalidCharacterMessage {
                 ErrorMessageCapsule(errorMessage: invalidCharacterMessage)
+                    .accessibilityIdentifier("invalidCharacterMessage")
                     .transition(.opacity)
             }
         }

--- a/Sources/SpeziAccessGuard/CodeViews/CodeView.swift
+++ b/Sources/SpeziAccessGuard/CodeViews/CodeView.swift
@@ -16,47 +16,52 @@ struct CodeView: View {
     @State private var code: String = ""
     @FocusState private var focused: Bool
     @State private var viewState: ViewState = .idle
+    @State private var invalidCharacterMessage: LocalizedStringResource?
+    @State private var dismissTask: Task<Void, Never>?
     
     var body: some View {
-        SecureField(String(), text: $code)
-            .textContentType(.password)
-            .keyboardType(codeFormat.keyboardType)
-            .textFieldStyle(.roundedBorder)
-            .focused($focused)
-            .disabled(viewState == .processing)
-            .accessibilityLabel(Text("PASSCODE_FIELD", bundle: .module))
-            .overlay {
-                ZStack {
-                    switch codeFormat.length {
-                    case .exact(let length), .atLeast(let length):
-                        Color(UIColor.systemBackground)
-                        HStack(spacing: 24) {
-                            ForEach(0..<length, id: \.self) { index in
-                                if code.count <= index {
-                                    Image(systemName: "circle")
-                                        .accessibilityHidden(true)
-                                } else {
-                                    Image(systemName: "circle.fill")
-                                        .accessibilityHidden(true)
+        VStack(spacing: 8) {
+            SecureField(String(), text: $code)
+                .textContentType(.password)
+                .keyboardType(codeFormat.keyboardType)
+                .textFieldStyle(.roundedBorder)
+                .focused($focused)
+                .disabled(viewState == .processing)
+                .accessibilityLabel(Text("PASSCODE_FIELD", bundle: .module))
+                .overlay {
+                    ZStack {
+                        switch codeFormat.length {
+                        case .exact(let length), .atLeast(let length):
+                            Color(UIColor.systemBackground)
+                            HStack(spacing: 24) {
+                                ForEach(0..<length, id: \.self) { index in
+                                    if code.count <= index {
+                                        Image(systemName: "circle")
+                                            .accessibilityHidden(true)
+                                    } else {
+                                        Image(systemName: "circle.fill")
+                                            .accessibilityHidden(true)
+                                    }
                                 }
                             }
                         }
                     }
-                }
-                .onTapGesture {
-                    focused = true
-                }
-            }
-            .task {
-                focused = true
-            }
-            .onChange(of: code) {
-                if codeFormat.validate(code: code) {
-                    Task { @MainActor in
-                        await checkCode()
+                    .onTapGesture {
+                        focused = true
                     }
                 }
+                .task {
+                    focused = true
+                }
+                .onChange(of: code) {
+                    codeDidChange()
+                }
+            if let invalidCharacterMessage {
+                ErrorMessageCapsule(errorMessage: invalidCharacterMessage)
+                    .transition(.opacity)
             }
+        }
+        .animation(.easeInOut, value: invalidCharacterMessage)
     }
     
     init(codeFormat: PasscodeFormat, action: @escaping @MainActor (String) async throws -> Void) {
@@ -64,6 +69,25 @@ struct CodeView: View {
         self.action = action
     }
     
+    private func codeDidChange() {
+        let filtered = codeFormat.filteringInvalidCharacters(from: code)
+        if filtered != code {
+            code = filtered
+            invalidCharacterMessage = codeFormat.invalidCharacterMessage
+            dismissTask?.cancel()
+            dismissTask = Task { @MainActor in
+                try? await Task.sleep(for: .seconds(2))
+                guard !Task.isCancelled else { return }
+                invalidCharacterMessage = nil
+            }
+        }
+        if codeFormat.validate(code: code) {
+            Task { @MainActor in
+                await checkCode()
+            }
+        }
+    }
+
     private func checkCode() async {
         focused = false
         viewState = .processing

--- a/Sources/SpeziAccessGuard/Resources/Localizable.xcstrings
+++ b/Sources/SpeziAccessGuard/Resources/Localizable.xcstrings
@@ -251,7 +251,6 @@
 
     },
     "PASSCODE_ONLY_DIGITS_ALLOWED" : {
-      "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -268,7 +267,6 @@
       }
     },
     "PASSCODE_ONLY_LETTERS_AND_DIGITS_ALLOWED" : {
-      "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/Sources/SpeziAccessGuard/Resources/Localizable.xcstrings
+++ b/Sources/SpeziAccessGuard/Resources/Localizable.xcstrings
@@ -250,6 +250,40 @@
     "Error: %@" : {
 
     },
+    "PASSCODE_ONLY_DIGITS_ALLOWED" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nur Ziffern sind erlaubt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Only digits are allowed"
+          }
+        }
+      }
+    },
+    "PASSCODE_ONLY_LETTERS_AND_DIGITS_ALLOWED" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nur Buchstaben und Ziffern sind erlaubt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Only letters and digits are allowed"
+          }
+        }
+      }
+    },
     "PASSCODE_FIELD" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Tests/SpeziAccessGuardTests/SpeziAccessGuardTests.swift
+++ b/Tests/SpeziAccessGuardTests/SpeziAccessGuardTests.swift
@@ -10,7 +10,20 @@
 import Testing
 
 
-@Test("Spezi Access Guard Works")
-func speziAccessGuardWorks() throws {
-    #expect(true)
+@Test func numericFormatFiltersLetters() {
+    let format = PasscodeFormat.numeric(4)
+    #expect(format.filteringInvalidCharacters(from: "1a2b") == "12")
+    #expect(format.filteringInvalidCharacters(from: "1234") == "1234")
+    #expect(format.filteringInvalidCharacters(from: "abcd") == "")
+}
+
+@Test func alphanumericFormatFiltersSpecialChars() {
+    let format = PasscodeFormat.alphanumeric(6)
+    #expect(format.filteringInvalidCharacters(from: "abc!@#") == "abc")
+    #expect(format.filteringInvalidCharacters(from: "ab12cd") == "ab12cd")
+}
+
+@Test func invalidCharacterMessageIsPresent() {
+    #expect(PasscodeFormat.numeric(4).invalidCharacterMessage != nil)
+    #expect(PasscodeFormat.alphanumeric(6).invalidCharacterMessage != nil)
 }

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -43,6 +43,13 @@ struct ContentView: View {
                             }
                         }
                     }
+                    NavigationLink("Access Guarded Alphanumeric") {
+                        AccessGuarded(.testAlphanumeric) {
+                            Color.green.overlay {
+                                Text("Secured with alphanumeric code ...")
+                            }
+                        }
+                    }
                     NavigationLink("Access Guarded Biometrics") {
                         AccessGuarded(.testBiometrics) {
                             Color.green.overlay {

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -20,6 +20,7 @@ class TestAppDelegate: SpeziAppDelegate {
                 BiometricAccessGuard(.testBiometrics)
                 CodeAccessGuard(.test, codeFormat: .numeric(4), isOptional: true, timeout: .seconds(10))
                 CodeAccessGuard(.testFixed, fixed: "1234")
+                CodeAccessGuard(.testAlphanumeric, fixed: "abc123")
                 CodeAccessGuard(.testConsumable, format: .numeric(4)) { code in
                     await consumableCodes.validate(code)
                 }
@@ -32,6 +33,7 @@ class TestAppDelegate: SpeziAppDelegate {
 extension AccessGuardIdentifier where AccessGuard == CodeAccessGuard {
     static let test: Self = .passcode("edu.stanford.spezi.accessguardtests.1.test")
     static let testFixed: Self = .passcode("edu.stanford.spezi.accessguardtests.1.testFixed")
+    static let testAlphanumeric: Self = .passcode("edu.stanford.spezi.accessguardtests.1.testAlphanumeric")
     static let testConsumable: Self = .passcode("edu.stanford.spezi.accessguardtests.1.testConsumable")
 }
 

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -222,6 +222,31 @@ class TestAppUITests: XCTestCase {
     }
     
     
+    func testInvalidCharacterFiltering() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        app.buttons["Access Guarded Alphanumeric"].tap()
+        XCTAssert(app.staticTexts["Enter Passcode"].waitForExistence(timeout: 5.0))
+
+        let passcodeField = app.secureTextFields.firstMatch
+        XCTAssert(passcodeField.waitForExistence(timeout: 2.0))
+        passcodeField.tap()
+
+        // Type an invalid character for an alphanumeric passcode — it should be filtered and an error shown
+        passcodeField.typeText("!")
+        let errorCapsule = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier == 'invalidCharacterMessage'"))
+            .firstMatch
+        XCTAssert(errorCapsule.waitForExistence(timeout: 2.0))
+
+        // Valid input should still work after the invalid character is filtered
+        passcodeField.tap()
+        passcodeField.typeText("abc123")
+        XCTAssert(app.staticTexts["Secured with alphanumeric code ..."].waitForExistence(timeout: 2.0))
+    }
+
+
     func testCustomCodeBehaviour() {
         enum ExpectedUnlockBehaviour {
             case success


### PR DESCRIPTION
# Filter invalid passcode characters and show descriptive error message

## :recycle: Current situation & Problem

Closes #10.

On iPad or when an external keyboard is connected, the `.numberPad` keyboard type does not prevent all non-numeric input — letters and special characters can still reach the passcode field via hardware key presses or paste. When this happens, the field silently accepts the invalid characters and the user receives no feedback about why their code is not being accepted.

## :gear: Release Notes

- Invalid characters are now silently stripped from the passcode field as the user types or pastes input.
- A brief, localised error capsule is shown below the passcode dots when characters are rejected (e.g. "Only digits are allowed" for `.numeric` formats).
- The error capsule disappears automatically after 2 seconds. If the user triggers another rejection before the timer expires, the timer resets so the message is always visible for a full 2 seconds from the last rejection.
- New `PasscodeFormat` API (internal):
  - `filteringInvalidCharacters(from:) -> String`
  - `invalidCharacterMessage: LocalizedStringResource?`

## :books: Documentation

All new methods are documented with Swift doc comments inline. No public API surface has changed.

## :white_check_mark: Testing

- Unit tests added for `filteringInvalidCharacters(from:)` covering numeric filtering, alphanumeric filtering, and presence of `invalidCharacterMessage`.
- Manually tested on iPhone 17 Pro simulator and iPad simulator with hardware keyboard and clipboard paste.

## :pencil: Code of Conduct & Contributing Guidelines

- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time input sanitization removes invalid characters as you type and shows an animated error capsule that auto-dismisses after 2 seconds.
  * Improved field focus and interaction: tapping focuses the input and validation proceeds when input becomes valid.

* **Localization**
  * Added localized messages for numeric and alphanumeric passcode rules (English and German).

* **Tests**
  * New unit and UI tests covering invalid-character filtering and the error message behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->